### PR TITLE
allow default type to be set by the parent firmware

### DIFF
--- a/examples/InputExample/InputExample.ino
+++ b/examples/InputExample/InputExample.ino
@@ -18,13 +18,13 @@ void setup() {
   for (uint8_t pin = 0; pin < 16; pin++) {
     mcp23017.pinMode(pin, INPUT_PULLUP);
   }
+  
+  // Initialise our input handler
+  oxrsInput.begin(inputEvent);
 
   // Set pin 0 to be a BUTTON type and invert
   oxrsInput.setType(0, BUTTON);
   oxrsInput.setInvert(0, 1);
-  
-  // Register our callback handler
-  oxrsInput.onEvent(inputEvent);
 }
 
 void loop() {

--- a/examples/InterlockExample/InterlockExample.ino
+++ b/examples/InterlockExample/InterlockExample.ino
@@ -22,12 +22,12 @@ void setup() {
     mcp23017.pinMode(pin, OUTPUT);
   }
 
+  // Initialise our output handler
+  oxrsOutput.begin(outputEvent);
+  
   // Set pins 0 and 1 to be interlocked
   oxrsOutput.setInterlock(0, 1);
   oxrsOutput.setInterlock(1, 0);
-  
-  // Register our callback handler
-  oxrsOutput.onEvent(outputEvent);
 }
 
 void loop() {

--- a/examples/TimerExample/TimerExample.ino
+++ b/examples/TimerExample/TimerExample.ino
@@ -21,12 +21,12 @@ void setup() {
     mcp23017.pinMode(pin, OUTPUT);
   }
 
+  // Initialise our output handler
+  oxrsOutput.begin(outputEvent);
+
   // Set pin 0 to have a 2s timer
   oxrsOutput.setType(0, TIMER);
   oxrsOutput.setTimer(0, 2);
-  
-  // Register our callback handler
-  oxrsOutput.onEvent(outputEvent);
 }
 
 void loop() {

--- a/keywords.txt
+++ b/keywords.txt
@@ -18,9 +18,9 @@ setInterlock	KEYWORD2
 getTimer			KEYWORD2
 setTimer			KEYWORD2
 
+begin		KEYWORD2
 process		KEYWORD2
 handleCommand	KEYWORD2
-onEvent		KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OXRS-SHA-IOHandler-ESP32-LIB
-version=1.0.0
+version=1.1.0
 author=SuperHouse Automation Pty Ltd
 maintainer=Ben Jones <ben.jones@gmail.com>
 sentence=ESP32 I/O handler library for Open eXtensible Rack System firmware

--- a/src/OXRS_Input.cpp
+++ b/src/OXRS_Input.cpp
@@ -10,14 +10,17 @@
 #include "Arduino.h"
 #include "OXRS_Input.h"
 
-OXRS_Input::OXRS_Input() 
+void OXRS_Input::begin(eventCallback callback, uint8_t defaultType) 
 {
+  // Store a reference to our event callback
+  _callback = callback; 
+
   // Initialise our state variables
   _lastUpdateTime = 0;
   for (uint8_t i = 0; i < INPUT_COUNT; i++)
   {
-    // Default all inputs to non-inverted switches
-    setType(i, SWITCH);
+    // Default all inputs
+    setType(i, defaultType);
     setInvert(i, 0);
 
     // Assume all inputs are in-active - i.e. HIGH
@@ -65,11 +68,6 @@ void OXRS_Input::setInvert(uint8_t input, uint8_t invert)
   _invert = (_invert & mask) | ((uint16_t)invert << input);
 }
 
-void OXRS_Input::onEvent(eventCallback callback)
-{ 
-  _onEvent = callback; 
-}
-
 void OXRS_Input::process(uint8_t id, uint16_t value) 
 {
   // Process each input to see what, if any, events have occured
@@ -77,14 +75,14 @@ void OXRS_Input::process(uint8_t id, uint16_t value)
   _update(event, value);
 
   // Check if we have a callback to handle the press events
-  if (_onEvent) 
+  if (_callback) 
   {
     for (uint8_t i = 0; i < INPUT_COUNT; i++)
     {
       // Only interested in inputs with events to report
       if (event[i] != NO_EVENT) 
       {
-        _onEvent(id, i, getType(i), event[i]);
+        _callback(id, i, getType(i), event[i]);
       }
     }
   }

--- a/src/OXRS_Input.h
+++ b/src/OXRS_Input.h
@@ -128,6 +128,7 @@ typedef void (*eventCallback)(uint8_t, uint8_t, uint8_t, uint8_t);
 class OXRS_Input
 {
   public:
+    // Initialise the input handler
     void begin(eventCallback, uint8_t defaultType=SWITCH);
 
     // Get/Set the input type
@@ -138,7 +139,7 @@ class OXRS_Input
     uint8_t getInvert(uint8_t input);
     void setInvert(uint8_t input, uint8_t invert);
 
-    // Process this set of button values and send events via onButtonPressed
+    // Call on each MCU loop to process input values and raise events
     void process(uint8_t id, uint16_t value);
 
   private:

--- a/src/OXRS_Input.h
+++ b/src/OXRS_Input.h
@@ -128,7 +128,7 @@ typedef void (*eventCallback)(uint8_t, uint8_t, uint8_t, uint8_t);
 class OXRS_Input
 {
   public:
-    OXRS_Input();
+    void begin(eventCallback, uint8_t defaultType=SWITCH);
 
     // Get/Set the input type
     uint8_t getType(uint8_t input);
@@ -141,16 +141,13 @@ class OXRS_Input
     // Process this set of button values and send events via onButtonPressed
     void process(uint8_t id, uint16_t value);
 
-    // Set callback function to be called when is button event is detected
-    void onEvent(eventCallback);
-
   private:
     // Configuration variables
     uint8_t _type[8];
     uint16_t _invert;
     
     // Input event callback
-    eventCallback _onEvent;
+    eventCallback _callback;
 
     // State variables    
     // _lastUpdateTime: the last time we processed an update, allows for efficient calculation 

--- a/src/OXRS_Output.cpp
+++ b/src/OXRS_Output.cpp
@@ -10,13 +10,16 @@
 #include "Arduino.h"
 #include "OXRS_Output.h"
 
-OXRS_Output::OXRS_Output() 
+void OXRS_Output::begin(eventCallback callback, uint8_t defaultType) 
 {
+  // Store a reference to our event callback
+  _callback = callback; 
+
   // Initialise our state variables
   for (uint8_t i = 0; i < OUTPUT_COUNT; i++)
   {
-    // Default all outputs to relays, no interlock, and default timer
-    setType(i, RELAY);
+    // Default all outputs
+    setType(i, defaultType);
     setInterlock(i, i);
     setTimer(i, DEFAULT_TIMER_SECS);
 
@@ -72,11 +75,6 @@ uint16_t OXRS_Output::getTimer(uint8_t output)
 void OXRS_Output::setTimer(uint8_t output, uint16_t timer)
 {
   _timer[output] = timer;
-}
-
-void OXRS_Output::onEvent(eventCallback callback)
-{ 
-  _onEvent = callback; 
 }
 
 void OXRS_Output::process()
@@ -153,9 +151,9 @@ uint8_t OXRS_Output::_updateOutput(uint8_t id, uint8_t output, uint8_t state)
   }
 
   // Check if we have a callback to handle events
-  if (_onEvent) 
+  if (_callback) 
   {
-    _onEvent(id, output, getType(output), state);
+    _callback(id, output, getType(output), state);
   }
 
   // Update the state of this output

--- a/src/OXRS_Output.h
+++ b/src/OXRS_Output.h
@@ -52,7 +52,7 @@ typedef void (*eventCallback)(uint8_t, uint8_t, uint8_t, uint8_t);
 class OXRS_Output
 {
   public:
-    OXRS_Output();
+    void begin(eventCallback, uint8_t defaultType=RELAY);
 
     // Get/Set the output type
     uint8_t getType(uint8_t output);
@@ -71,9 +71,6 @@ class OXRS_Output
     
     // Handle a command to set the state for a specific output
     void handleCommand(uint8_t id, uint8_t output, uint8_t state);
-    
-    // Set callback function to be called when an output is changed
-    void onEvent(eventCallback);
 
   private:
     // Configuration variables
@@ -96,7 +93,7 @@ class OXRS_Output
     outputData_t _state[OUTPUT_COUNT];
 
     // Output event callback
-    eventCallback _onEvent;
+    eventCallback _callback;
 
     // Private methods
     uint8_t _updateOutput(uint8_t id, uint8_t output, uint8_t state);

--- a/src/OXRS_Output.h
+++ b/src/OXRS_Output.h
@@ -52,6 +52,7 @@ typedef void (*eventCallback)(uint8_t, uint8_t, uint8_t, uint8_t);
 class OXRS_Output
 {
   public:
+    // Initialise the output handler
     void begin(eventCallback, uint8_t defaultType=RELAY);
 
     // Get/Set the output type


### PR DESCRIPTION
Breaking change unfortunately. Means a user can modify their firmware to set the default type for input/output handlers.

This becomes useful when thinking about how the device will work in failover mode, when it restarts and doesn't have an MQTT broker to connect to and retrieve configuration. In that case I would want all my wall switches to default to `TOGGLE` type so I can write simple internal mappings knowing each input is only reporting one type of event.

I also think having `.begin()` is more consistent with typical Arduino libraries. 